### PR TITLE
Implement basic role-based login

### DIFF
--- a/starter-kit/app/Http/Controllers/AuthController.php
+++ b/starter-kit/app/Http/Controllers/AuthController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class AuthController extends Controller
+{
+    /**
+     * Handle login request
+     */
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+
+            return response()->json([
+                'success' => true,
+                'user' => Auth::user(),
+            ]);
+        }
+
+        return response()->json([
+            'success' => false,
+            'message' => 'Invalid credentials',
+        ], 401);
+    }
+
+    /**
+     * Logout current user
+     */
+    public function logout(Request $request)
+    {
+        Auth::guard('web')->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/starter-kit/app/Http/Middleware/CheckRole.php
+++ b/starter-kit/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next, string $role)
+    {
+        $user = Auth::user();
+        if (!$user || $user->role !== $role) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/starter-kit/app/Models/User.php
+++ b/starter-kit/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/starter-kit/bootstrap/app.php
+++ b/starter-kit/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/starter-kit/database/migrations/2025_04_01_000000_add_role_to_users_table.php
+++ b/starter-kit/database/migrations/2025_04_01_000000_add_role_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('store');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/starter-kit/database/seeders/DatabaseSeeder.php
+++ b/starter-kit/database/seeders/DatabaseSeeder.php
@@ -16,8 +16,15 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'role' => 'admin',
+        ]);
+
+        User::factory()->create([
+            'name' => 'Store User',
+            'email' => 'store@example.com',
+            'role' => 'store',
         ]);
     }
 }

--- a/starter-kit/resources/js/layouts/components/DefaultLayoutWithVerticalNav.vue
+++ b/starter-kit/resources/js/layouts/components/DefaultLayoutWithVerticalNav.vue
@@ -1,5 +1,6 @@
 <script setup>
-import navItems from '@/navigation/vertical'
+import useNavItems from '@/navigation/vertical'
+import { computed } from 'vue'
 import { themeConfig } from '@themeConfig'
 
 // Components
@@ -13,6 +14,7 @@ import { useConfigStore } from '@/@core/stores/config'
 import { VerticalNavLayout } from '@layouts'
 
 const configStore = useConfigStore()
+const navItems = computed(() => useNavItems())
 
 // ℹ️ Provide animation name for vertical nav collapse icon.
 const verticalNavHeaderActionAnimationName = ref(null)

--- a/starter-kit/resources/js/navigation/vertical/index.js
+++ b/starter-kit/resources/js/navigation/vertical/index.js
@@ -1,10 +1,12 @@
-export default [
+import { storeToRefs } from 'pinia'
+import { useAuthStore } from '@/stores/auth'
+
+const storeNav = [
   {
     title: 'Home',
     to: { name: 'second-page' },
     icon: { icon: 'bx-home-alt' },
   },
- 
   {
     title: 'Project',
     to: { name: 'project' },
@@ -20,8 +22,9 @@ export default [
     to: { name: 'prize' },
     icon: { icon: 'bx-receipt' },
   },
- 
- 
+]
+
+const adminExtra = [
   {
     title: 'Package Management',
     to: { name: 'packagemanagement' },
@@ -33,3 +36,8 @@ export default [
     icon: { icon: 'bx-user' },
   },
 ]
+
+export default function useVerticalNavigation() {
+  const { role } = storeToRefs(useAuthStore())
+  return role.value === 'admin' ? [...storeNav, ...adminExtra] : storeNav
+}

--- a/starter-kit/resources/js/pages/customer.vue
+++ b/starter-kit/resources/js/pages/customer.vue
@@ -215,6 +215,12 @@
 <script setup>
 import axios from 'axios'
 import { computed, onMounted, ref } from 'vue'
+definePage({
+  meta: {
+    requiresAuth: true,
+    role: 'store',
+  },
+})
 import {
   VAvatar,
   VBtn,

--- a/starter-kit/resources/js/pages/login.vue
+++ b/starter-kit/resources/js/pages/login.vue
@@ -3,6 +3,9 @@ import AuthProvider from '@/views/pages/authentication/AuthProvider.vue'
 import { VNodeRenderer } from '@layouts/components/VNodeRenderer'
 import { themeConfig } from '@themeConfig'
 import authV2LoginIllustration from '@images/pages/auth-v2-login-illustration.png'
+import { useApi } from '@/composables/useApi'
+import { useAuthStore } from '@/stores/auth'
+import { useRouter } from 'vue-router'
 
 definePage({
   meta: {
@@ -18,6 +21,24 @@ const form = ref({
 })
 
 const isPasswordVisible = ref(false)
+
+const api = useApi()
+const authStore = useAuthStore()
+const router = useRouter()
+
+async function handleLogin() {
+  const { data } = await api('/login', {
+    method: 'POST',
+    body: { email: form.email, password: form.password },
+  })
+
+  if (data?.success) {
+    authStore.setUser(data.user)
+    router.push({ name: 'second-page' })
+  } else {
+    alert(data?.message || 'Login failed')
+  }
+}
 </script>
 
 <template>
@@ -70,7 +91,7 @@ const isPasswordVisible = ref(false)
           </p>
         </VCardText>
         <VCardText>
-          <VForm @submit.prevent="() => {}">
+          <VForm @submit.prevent="handleLogin">
             <VRow>
               <!-- email -->
               <VCol cols="12">

--- a/starter-kit/resources/js/pages/packagemanagement.vue
+++ b/starter-kit/resources/js/pages/packagemanagement.vue
@@ -108,6 +108,12 @@
 <script setup>
 import axios from 'axios'
 import { onMounted, ref } from 'vue'
+definePage({
+  meta: {
+    requiresAuth: true,
+    role: 'admin',
+  },
+})
 
 // กรณีใช้ Laravel Sanctum + SPA ให้ปลดคอมเมนต์ถ้าจำเป็น
 // axios.defaults.withCredentials = true

--- a/starter-kit/resources/js/pages/prize.vue
+++ b/starter-kit/resources/js/pages/prize.vue
@@ -190,6 +190,12 @@
 <script setup>
 import { ref, onMounted, nextTick, computed } from 'vue'
 import axios from 'axios'
+definePage({
+  meta: {
+    requiresAuth: true,
+    role: 'store',
+  },
+})
 
 // ======= Mock Data =======
 const mockRewards = [

--- a/starter-kit/resources/js/pages/project.vue
+++ b/starter-kit/resources/js/pages/project.vue
@@ -276,6 +276,12 @@
 import { ref, reactive, computed } from 'vue'
 import axios from 'axios'
 import { useRouter } from 'vue-router'
+definePage({
+  meta: {
+    requiresAuth: true,
+    role: 'store',
+  },
+})
 
 // Stepper items
 const iconsSteps = [

--- a/starter-kit/resources/js/plugins/1.router/index.js
+++ b/starter-kit/resources/js/plugins/1.router/index.js
@@ -1,5 +1,6 @@
 import { setupLayouts } from 'virtual:generated-layouts'
 import { createRouter, createWebHistory } from 'vue-router/auto'
+import { useAuthStore } from '@/stores/auth'
 
 function recursiveLayouts(route) {
   if (route.children) {
@@ -23,6 +24,20 @@ const router = createRouter({
   extendRoutes: pages => [
     ...[...pages].map(route => recursiveLayouts(route)),
   ],
+})
+
+router.beforeEach((to, _, next) => {
+  const auth = useAuthStore()
+  const requiresAuth = to.meta?.requiresAuth
+  const role = to.meta?.role
+
+  if (requiresAuth && !auth.role.value)
+    return next({ name: 'login' })
+
+  if (role && auth.role.value !== role)
+    return next(false)
+
+  next()
 })
 
 export { router }

--- a/starter-kit/resources/js/stores/auth.js
+++ b/starter-kit/resources/js/stores/auth.js
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useCookie } from '@vueuse/integrations/useCookie'
+
+export const useAuthStore = defineStore('auth', () => {
+  const user = ref(null)
+  const role = useCookie('role', '')
+
+  function setUser(value) {
+    user.value = value
+    role.value = value?.role || ''
+  }
+
+  return { user, role, setUser }
+})

--- a/starter-kit/routes/api.php
+++ b/starter-kit/routes/api.php
@@ -5,46 +5,49 @@ use App\Http\Controllers\QuizUserController;
 use App\Http\Controllers\CouponController;
 use App\Http\Controllers\PackageController;
 use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\AuthController;
 
 // Resource หลัก
-Route::resource('quiz-users', QuizUserController::class)->only([
-    'index',
-    'store',
-    'show',
-    'update',
-    'destroy'
-]);
+Route::middleware('role:store')->group(function () {
+    Route::resource('quiz-users', QuizUserController::class)->only([
+        'index',
+        'store',
+        'show',
+        'update',
+        'destroy'
+    ]);
 
-// บันทึก/อัปเดตข้อมูล PDPA หรือข้อมูลอื่น ๆ
-Route::post('quiz-users/store-or-update', [QuizUserController::class, 'storeOrUpdate']);
+    // บันทึก/อัปเดตข้อมูล PDPA หรือข้อมูลอื่น ๆ
+    Route::post('quiz-users/store-or-update', [QuizUserController::class, 'storeOrUpdate']);
 
-// *** ดึงข้อมูล user จาก line_udid ***
-Route::get('users/profile', [QuizUserController::class, 'profileByLineUdid']);
+    // *** ดึงข้อมูล user จาก line_udid ***
+    Route::get('users/profile', [QuizUserController::class, 'profileByLineUdid']);
 
-// *** ตรวจสอบคูปอง (ตัวอย่าง) ***
-Route::post('quiz-users/apply-coupon', [QuizUserController::class, 'applyCoupon']);
+    // *** ตรวจสอบคูปอง (ตัวอย่าง) ***
+    Route::post('quiz-users/apply-coupon', [QuizUserController::class, 'applyCoupon']);
 
-// *** (ใหม่) ตัด coin สำหรับทำ Quiz ***
-Route::post('quiz-users/deduct-coin', [QuizUserController::class, 'deductCoinForQuiz']);
+    // *** (ใหม่) ตัด coin สำหรับทำ Quiz ***
+    Route::post('quiz-users/deduct-coin', [QuizUserController::class, 'deductCoinForQuiz']);
 
-// *** ส่งผลลัพธ์ Quiz (เก็บ styles, types, quiz_link และ +1 quiz_attempts) ***
-Route::post('quiz-users/submit-quiz', [QuizUserController::class, 'submitQuizResult']);
+    // *** ส่งผลลัพธ์ Quiz (เก็บ styles, types, quiz_link และ +1 quiz_attempts) ***
+    Route::post('quiz-users/submit-quiz', [QuizUserController::class, 'submitQuizResult']);
+});
 
-// Resource อื่น ๆ
-Route::apiResource('coupons', CouponController::class);
-Route::apiResource('packages', PackageController::class);
+// Resource อื่น ๆ สำหรับผู้ดูแลระบบ
+Route::middleware('role:admin')->group(function () {
+    Route::apiResource('coupons', CouponController::class);
+    Route::apiResource('packages', PackageController::class);
+});
 
 // ตัวอย่าง Payment
 Route::post('/create-promptpay-intent', [PaymentController::class, 'createPromptpayIntent']);
-
-Route::get('/coupons', [CouponController::class, 'index']);
-Route::post('/coupons', [CouponController::class, 'store']);
-Route::get('/coupons/{id}', [CouponController::class, 'show']);
-Route::put('/coupons/{id}', [CouponController::class, 'update']);
-Route::delete('/coupons/{id}', [CouponController::class, 'destroy']);
 
 // สำคัญ: เส้นทาง apply-coupon
 Route::post('/coupons/apply-coupon', [CouponController::class, 'applyCoupon']);
 
 Route::post('/quiz-users/send-flex-to-multiple', [QuizUserController::class, 'sendFlexToMultiple']);
+
+// Authentication
+Route::post('login', [AuthController::class, 'login']);
+Route::post('logout', [AuthController::class, 'logout']);
 


### PR DESCRIPTION
## Summary
- add role column and seed admin/store users
- create AuthController with login and logout routes
- add role-check middleware and register alias
- restrict API routes by role
- store user role on login and generate navigation based on role
- add router guard to enforce access

## Testing
- `php artisan test` *(fails: php not installed)*