### PR TITLE
Add user-linked store, project, and reward tables

### DIFF
--- a/starter-kit/app/Http/Controllers/ProjectController.php
+++ b/starter-kit/app/Http/Controllers/ProjectController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use Illuminate\Http\Request;
+
+class ProjectController extends Controller
+{
+    public function index()
+    {
+        return Project::all();
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'store_id' => 'required|exists:stores,id',
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'theme_color' => 'nullable|string',
+            'text_color' => 'nullable|string',
+            'banner_image_url' => 'nullable|string',
+            'profile_image_url' => 'nullable|string',
+        ]);
+
+        $project = Project::create($validated);
+
+        return response()->json($project, 201);
+    }
+
+    public function show($id)
+    {
+        return Project::findOrFail($id);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $project = Project::findOrFail($id);
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'description' => 'nullable|string',
+            'theme_color' => 'nullable|string',
+            'text_color' => 'nullable|string',
+            'banner_image_url' => 'nullable|string',
+            'profile_image_url' => 'nullable|string',
+        ]);
+
+        $project->update($validated + [
+            'user_id' => $request->input('user_id', $project->user_id),
+            'store_id' => $request->input('store_id', $project->store_id),
+        ]);
+
+        return response()->json($project);
+    }
+
+    public function destroy($id)
+    {
+        $project = Project::findOrFail($id);
+        $project->delete();
+
+        return response()->json(null, 204);
+    }
+}
+

--- a/starter-kit/app/Http/Controllers/RewardController.php
+++ b/starter-kit/app/Http/Controllers/RewardController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Reward;
+use Illuminate\Http\Request;
+
+class RewardController extends Controller
+{
+    public function index()
+    {
+        return Reward::all();
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'project_id' => 'required|exists:projects,id',
+            'name' => 'required|string|max:255',
+            'detail' => 'nullable|string',
+            'color' => 'nullable|string',
+            'quantity' => 'required|integer',
+            'chance' => 'required|integer',
+        ]);
+
+        $reward = Reward::create($validated);
+
+        return response()->json($reward, 201);
+    }
+
+    public function show($id)
+    {
+        return Reward::findOrFail($id);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $reward = Reward::findOrFail($id);
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'detail' => 'nullable|string',
+            'color' => 'nullable|string',
+            'quantity' => 'sometimes|integer',
+            'chance' => 'sometimes|integer',
+        ]);
+
+        $reward->update($validated + [
+            'user_id' => $request->input('user_id', $reward->user_id),
+            'project_id' => $request->input('project_id', $reward->project_id),
+        ]);
+
+        return response()->json($reward);
+    }
+
+    public function destroy($id)
+    {
+        $reward = Reward::findOrFail($id);
+        $reward->delete();
+
+        return response()->json(null, 204);
+    }
+}
+

--- a/starter-kit/app/Http/Controllers/StoreController.php
+++ b/starter-kit/app/Http/Controllers/StoreController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Store;
+use Illuminate\Http\Request;
+
+class StoreController extends Controller
+{
+    public function index()
+    {
+        return Store::all();
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'address' => 'nullable|string',
+        ]);
+
+        $store = Store::create($validated);
+
+        return response()->json($store, 201);
+    }
+
+    public function show($id)
+    {
+        return Store::findOrFail($id);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $store = Store::findOrFail($id);
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'description' => 'nullable|string',
+            'address' => 'nullable|string',
+        ]);
+
+        $store->update($validated + ['user_id' => $request->input('user_id', $store->user_id)]);
+
+        return response()->json($store);
+    }
+
+    public function destroy($id)
+    {
+        $store = Store::findOrFail($id);
+        $store->delete();
+
+        return response()->json(null, 204);
+    }
+}
+

--- a/starter-kit/app/Models/Project.php
+++ b/starter-kit/app/Models/Project.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Project extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'store_id',
+        'name',
+        'description',
+        'theme_color',
+        'text_color',
+        'banner_image_url',
+        'profile_image_url',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function rewards()
+    {
+        return $this->hasMany(Reward::class);
+    }
+}
+

--- a/starter-kit/app/Models/Reward.php
+++ b/starter-kit/app/Models/Reward.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Reward extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'project_id',
+        'name',
+        'detail',
+        'color',
+        'quantity',
+        'chance',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+}
+

--- a/starter-kit/app/Models/Store.php
+++ b/starter-kit/app/Models/Store.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Store extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'description',
+        'address',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function projects()
+    {
+        return $this->hasMany(Project::class);
+    }
+}
+

--- a/starter-kit/database/migrations/2025_04_01_000000_create_stores_table.php
+++ b/starter-kit/database/migrations/2025_04_01_000000_create_stores_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('stores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('stores');
+    }
+};
+

--- a/starter-kit/database/migrations/2025_04_01_000001_create_projects_table.php
+++ b/starter-kit/database/migrations/2025_04_01_000001_create_projects_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('store_id')->constrained('stores');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('theme_color')->nullable();
+            $table->string('text_color')->nullable();
+            $table->string('banner_image_url')->nullable();
+            $table->string('profile_image_url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('projects');
+    }
+};
+

--- a/starter-kit/database/migrations/2025_04_01_000002_create_rewards_table.php
+++ b/starter-kit/database/migrations/2025_04_01_000002_create_rewards_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('rewards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('project_id')->constrained('projects');
+            $table->string('name');
+            $table->text('detail')->nullable();
+            $table->string('color')->nullable();
+            $table->integer('quantity');
+            $table->integer('chance');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('rewards');
+    }
+};
+

--- a/starter-kit/routes/api.php
+++ b/starter-kit/routes/api.php
@@ -5,6 +5,9 @@ use App\Http\Controllers\QuizUserController;
 use App\Http\Controllers\CouponController;
 use App\Http\Controllers\PackageController;
 use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\StoreController;
+use App\Http\Controllers\ProjectController;
+use App\Http\Controllers\RewardController;
 
 // Resource หลัก
 Route::resource('quiz-users', QuizUserController::class)->only([
@@ -33,6 +36,9 @@ Route::post('quiz-users/submit-quiz', [QuizUserController::class, 'submitQuizRes
 // Resource อื่น ๆ
 Route::apiResource('coupons', CouponController::class);
 Route::apiResource('packages', PackageController::class);
+Route::apiResource('stores', StoreController::class);
+Route::apiResource('projects', ProjectController::class);
+Route::apiResource('rewards', RewardController::class);
 
 // ตัวอย่าง Payment
 Route::post('/create-promptpay-intent', [PaymentController::class, 'createPromptpayIntent']);


### PR DESCRIPTION
## Summary
- create migrations for `stores`, `projects` and `rewards` that link records to the `users` table
- add models for Store, Project and Reward
- add controllers for managing these resources
- expose new API routes for stores, projects and rewards

## Testing
- `phpunit --version` *(fails: command not found)*