### PR TITLE
Add store, campaign and reward support

### DIFF
--- a/starter-kit/app/Http/Controllers/CampaignController.php
+++ b/starter-kit/app/Http/Controllers/CampaignController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Campaign;
+use App\Models\Store;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CampaignController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'place.place_id' => 'required|string',
+            'place.name' => 'required|string',
+            'place.formatted_address' => 'required|string',
+            'project.name' => 'required|string',
+        ]);
+
+        $userId = Auth::id();
+
+        $store = Store::create([
+            'user_id'      => $userId,
+            'place_id'     => $request->input('place.place_id'),
+            'name'         => $request->input('place.name'),
+            'address'      => $request->input('place.formatted_address'),
+            'review_link'  => $request->input('review_link'),
+            'contact_name' => $request->input('registerForm.fullname'),
+            'contact_tel'  => $request->input('registerForm.tel'),
+        ]);
+
+        $project = $request->input('project', []);
+
+        $campaign = Campaign::create([
+            'user_id'          => $userId,
+            'store_id'         => $store->id,
+            'name'             => $project['name'] ?? '',
+            'description'      => $project['description'] ?? null,
+            'theme_color'      => $project['themeColor'] ?? null,
+            'text_color'       => $project['textColor'] ?? null,
+            'banner_image_url' => $project['bannerImageUrl'] ?? null,
+            'profile_image_url'=> $project['profileImageUrl'] ?? null,
+        ]);
+
+        return response()->json($campaign, 201);
+    }
+}

--- a/starter-kit/app/Http/Controllers/RewardController.php
+++ b/starter-kit/app/Http/Controllers/RewardController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Reward;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class RewardController extends Controller
+{
+    public function store(Request $request, $campaignId)
+    {
+        $request->validate([
+            'name'     => 'required|string',
+            'detail'   => 'nullable|string',
+            'color'    => 'nullable|string',
+            'quantity' => 'required|integer|min:1',
+            'chance'   => 'required|integer|min:1',
+        ]);
+
+        $reward = Reward::create([
+            'user_id'     => Auth::id(),
+            'campaign_id' => $campaignId,
+            'name'        => $request->name,
+            'detail'      => $request->detail,
+            'color'       => $request->color,
+            'quantity'    => $request->quantity,
+            'chance'      => $request->chance,
+        ]);
+
+        return response()->json($reward, 201);
+    }
+}

--- a/starter-kit/app/Models/Campaign.php
+++ b/starter-kit/app/Models/Campaign.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Campaign extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'store_id',
+        'name',
+        'description',
+        'theme_color',
+        'text_color',
+        'banner_image_url',
+        'profile_image_url',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function rewards()
+    {
+        return $this->hasMany(Reward::class);
+    }
+}

--- a/starter-kit/app/Models/Reward.php
+++ b/starter-kit/app/Models/Reward.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Reward extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'campaign_id',
+        'name',
+        'detail',
+        'color',
+        'quantity',
+        'chance',
+    ];
+
+    public function campaign()
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/starter-kit/app/Models/Store.php
+++ b/starter-kit/app/Models/Store.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Store extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'place_id',
+        'name',
+        'address',
+        'review_link',
+        'contact_name',
+        'contact_tel',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/starter-kit/database/migrations/2025_04_02_000000_create_stores_table.php
+++ b/starter-kit/database/migrations/2025_04_02_000000_create_stores_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('place_id')->nullable();
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->string('review_link')->nullable();
+            $table->string('contact_name')->nullable();
+            $table->string('contact_tel')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stores');
+    }
+};

--- a/starter-kit/database/migrations/2025_04_02_000001_create_campaigns_table.php
+++ b/starter-kit/database/migrations/2025_04_02_000001_create_campaigns_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('campaigns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('store_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('theme_color')->nullable();
+            $table->string('text_color')->nullable();
+            $table->string('banner_image_url')->nullable();
+            $table->string('profile_image_url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('campaigns');
+    }
+};

--- a/starter-kit/database/migrations/2025_04_02_000002_create_rewards_table.php
+++ b/starter-kit/database/migrations/2025_04_02_000002_create_rewards_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rewards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('campaign_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('detail')->nullable();
+            $table->string('color')->nullable();
+            $table->integer('quantity')->default(1);
+            $table->integer('chance')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rewards');
+    }
+};

--- a/starter-kit/routes/api.php
+++ b/starter-kit/routes/api.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\CouponController;
 use App\Http\Controllers\PackageController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\CampaignController;
+use App\Http\Controllers\RewardController;
 
 // Resource หลัก
 Route::middleware('role:store')->group(function () {
@@ -31,6 +33,10 @@ Route::middleware('role:store')->group(function () {
 
     // *** ส่งผลลัพธ์ Quiz (เก็บ styles, types, quiz_link และ +1 quiz_attempts) ***
     Route::post('quiz-users/submit-quiz', [QuizUserController::class, 'submitQuizResult']);
+
+    // สร้างแคมเปญและรางวัล
+    Route::post('campaigns', [CampaignController::class, 'store']);
+    Route::post('campaigns/{campaign}/rewards', [RewardController::class, 'store']);
 });
 
 // Resource อื่น ๆ สำหรับผู้ดูแลระบบ


### PR DESCRIPTION
## Summary
- add Store, Campaign and Reward models
- create migrations for stores, campaigns and rewards
- add controller endpoints to create campaigns and rewards
- wire routes for the new controllers

## Testing
- `php artisan test --testsuite Feature --filter ExampleTest` *(fails: `php: command not found`)*